### PR TITLE
Refactored a bunch of my old code to make the movement simpler.

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -180,7 +180,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.015396677, y: -0.053028107}
+  m_Offset: {x: 0.0073272586, y: -0.089340456}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -191,7 +191,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.14213805, y: 0.7415309}
+  m_Size: {x: 0.23090154, y: 0.67294097}
   m_EdgeRadius: 0
 --- !u!114 &-4693111913960648777
 MonoBehaviour:
@@ -224,6 +224,8 @@ MonoBehaviour:
   fallSpeed: 5000
   jumpPower: 2500
   jumpSpeed: 1000
+  setGroundedOnce: 1
+  xJumpConstraint: 1.5
   groundLayer:
     serializedVersion: 2
     m_Bits: 896


### PR DESCRIPTION
Greatly simplified the player movement, and added more aerial control for platforming. Fixed some bugs with movement and temporarily fixed the bug where the player shoots to the moon when next to a button. Currently, the ground check is hitting true to ground objects to the left and right of the player, like walls or buttons. So the player was getting multiple jump inputs when next to a wall or button. I temporarily fixed this by making the player hixbox wider so that the ground check cannot hit these side objects.